### PR TITLE
fix(docker-compose): specify username and database in postgres healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     volumes:
       - ./.postgres/data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: [ "CMD-SHELL", "pg_isready -d $POSTGRES_DB -U $POSTGRES_USER" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This commit fixes the error of role "root" does not exist when running healthcheck for postgres service in docker-compose.
需要在pg的healthcheck中指定用户，不然docker-compose会不停报`2023-07-13 17:19:16.813 UTC [34] FATAL: role "root" does not exist`的错误