### PR TITLE
fix(heatlhcheck): add curl to Dockerfile, supports to set password for Redis from envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go build -a -o "release/insights-bot" "github.com/nekomeowww/insights-bot/cm
 # --- runner ---
 FROM debian as runner
 
-RUN apt update && apt upgrade -y && apt install -y ca-certificates && update-ca-certificates
+RUN apt update && apt upgrade -y && apt install -y ca-certificates curl && update-ca-certificates
 
 COPY --from=builder /app/insights-bot/release/insights-bot /usr/local/bin/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,11 +116,12 @@ services:
   redis_local:
     image: redis:7
     restart: unless-stopped
-    # comment the following line if you don't want to set password for redis
+    environment:
+      - REDIS_PASSWORD=123456
     command: >
-      --requirepass 123456
+      ${REDIS_PASSWORD:+--requirepass \"$REDIS_PASSWORD}\"}
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping"]
+      test: ["CMD-SHELL", "redis-cli -e ${REDIS_PASSWORD:+-a \"$REDIS_PASSWORD\"} --no-auth-warning ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
     volumes:
       - ./.postgres/data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: [ "CMD-SHELL", "pg_isready" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -121,7 +121,7 @@ services:
     command: >
       ${REDIS_PASSWORD:+--requirepass \"$REDIS_PASSWORD}\"}
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -e ${REDIS_PASSWORD:+-a \"$REDIS_PASSWORD\"} --no-auth-warning ping"]
+      test: [ "CMD-SHELL", "redis-cli -e ${REDIS_PASSWORD:+-a \"$REDIS_PASSWORD\"} --no-auth-warning ping" ]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
This commit fixes the error of /bin/sh: 1: curl: not found when running healthcheck for insights_bot service in docker-compose.
需要在insights-bot容器内装上curl，否则 [这里的](https://github.com/nekomeowww/insights-bot/blob/d231e3769e88b822e7f361a56fc7f1381efc5ad8/docker-compose.yml#L33C13-L33C17) healthcheck会报`/bin/sh: 1: curl: not found`


